### PR TITLE
Added support for relocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ option(ALFLIBCPP_BUILD_SAMPLES "Build sample program" OFF)
 option(ALFLIBCPP_BUILD_TESTS "Build tests" OFF)
 
 # Language standard
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 # Compiler flags flags
 if (MSVC)

--- a/include/alflib/collection/array_list.hpp
+++ b/include/alflib/collection/array_list.hpp
@@ -29,13 +29,29 @@
 #include "alflib/memory/allocator.hpp"
 #include "alflib/core/assert.hpp"
 #include "alflib/core/common.hpp"
+#include "alflib/core/traits.hpp"
 #include "alflib/math/math.hpp"
+#include "alflib/memory/memory.hpp"
 
 // ========================================================================== //
 // ArrayList Declaration
 // ========================================================================== //
 
 namespace alflib {
+
+template<typename T, bool R>
+class ArrayList;
+
+// -------------------------------------------------------------------------- //
+
+/** \copydoc alflib::IsTriviallyRelocatable<T> **/
+template<typename T, bool R>
+struct IsTriviallyRelocatable<ArrayList<T, R>>
+{
+  static constexpr bool Value = IsTriviallyRelocatable<T>::Value;
+};
+
+// -------------------------------------------------------------------------- //
 
 /** \class ArrayList
  * \author Filip Björklund
@@ -46,7 +62,7 @@ namespace alflib {
  * Represents an array-list where each object in the list is layed out linearly
  * in memory.
  */
-template<typename T>
+template<typename T, bool R = IsTriviallyRelocatable<T>::Value>
 class ArrayList
 {
 public:
@@ -194,13 +210,13 @@ public:
    * \brief Remove object.
    * \param object Object to search for and remove.
    */
-  void Remove(const T& object);
+  void RemoveObject(const T& object);
 
   /** Remove an object from that list that is equal to the specified object.
    * \brief Remove object.
    * \param object Object to search for and remove.
    */
-  void Remove(T&& object);
+  void RemoveObject(T&& object);
 
   /** Resize the list to the specified size. This is useful if the user is using
    * the index operator to access objects instead of inserting them.
@@ -327,58 +343,58 @@ private:
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
-ArrayList<T>::Iterator::Iterator(PointerType pointer)
+template<typename T, bool R>
+ArrayList<T, R>::Iterator::Iterator(ArrayList::PointerType pointer)
   : mPointer(pointer)
 {}
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 void
-ArrayList<T>::Iterator::operator++()
+ArrayList<T, R>::Iterator::operator++()
 {
   ++mPointer;
 }
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 void
-ArrayList<T>::Iterator::operator--()
+ArrayList<T, R>::Iterator::operator--()
 {
   --mPointer;
 }
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 bool
-ArrayList<T>::Iterator::operator!=(const Iterator& other)
+ArrayList<T, R>::Iterator::operator!=(const Iterator& other)
 {
   return mPointer != other.mPointer;
 }
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
-typename ArrayList<T>::ReferenceType ArrayList<T>::Iterator::operator*()
+template<typename T, bool R>
+typename ArrayList<T, R>::ReferenceType ArrayList<T, R>::Iterator::operator*()
 {
   return *mPointer;
 }
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
-typename ArrayList<T>::PointerType ArrayList<T>::Iterator::operator->()
+template<typename T, bool R>
+typename ArrayList<T, R>::PointerType ArrayList<T, R>::Iterator::operator->()
 {
   return mPointer;
 }
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
-ArrayList<T>::ArrayList(u64 capacity, Allocator& allocator)
+template<typename T, bool R>
+ArrayList<T, R>::ArrayList(u64 capacity, Allocator& allocator)
   : mBuffer(nullptr)
   , mCapacity(capacity)
   , mSize(0)
@@ -390,9 +406,9 @@ ArrayList<T>::ArrayList(u64 capacity, Allocator& allocator)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
-ArrayList<T>::ArrayList(std::initializer_list<T> initializerList,
-                        Allocator& allocator)
+template<typename T, bool R>
+ArrayList<T, R>::ArrayList(std::initializer_list<T> initializerList,
+                           Allocator& allocator)
   : mCapacity(initializerList.size())
   , mSize(0)
   , mAllocator(allocator)
@@ -406,8 +422,8 @@ ArrayList<T>::ArrayList(std::initializer_list<T> initializerList,
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
-ArrayList<T>::ArrayList(const ArrayList& other)
+template<typename T, bool R>
+ArrayList<T, R>::ArrayList(const ArrayList& other)
   : mCapacity(other.mCapacity)
   , mSize(other.mSize)
   , mAllocator(other.mAllocator)
@@ -421,8 +437,8 @@ ArrayList<T>::ArrayList(const ArrayList& other)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
-ArrayList<T>::ArrayList(ArrayList&& other)
+template<typename T, bool R>
+ArrayList<T, R>::ArrayList(ArrayList&& other)
   : mBuffer(other.mBuffer)
   , mCapacity(other.mCapacity)
   , mSize(other.mSize)
@@ -435,8 +451,8 @@ ArrayList<T>::ArrayList(ArrayList&& other)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
-ArrayList<T>::~ArrayList()
+template<typename T, bool R>
+ArrayList<T, R>::~ArrayList()
 {
   for (SizeType i = 0; i < mSize; ++i) {
     mBuffer[i].~T();
@@ -446,9 +462,9 @@ ArrayList<T>::~ArrayList()
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
-ArrayList<T>&
-ArrayList<T>::operator=(const ArrayList& other)
+template<typename T, bool R>
+ArrayList<T, R>&
+ArrayList<T, R>::operator=(const ArrayList& other)
 {
   if (this != &other) {
     // Destruct this list
@@ -472,9 +488,9 @@ ArrayList<T>::operator=(const ArrayList& other)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
-ArrayList<T>&
-ArrayList<T>::operator=(ArrayList&& other)
+template<typename T, bool R>
+ArrayList<T, R>&
+ArrayList<T, R>::operator=(ArrayList&& other)
 {
   if (this != &other) {
     // Destruct this list
@@ -497,9 +513,9 @@ ArrayList<T>::operator=(ArrayList&& other)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 void
-ArrayList<T>::Append(const T& object)
+ArrayList<T, R>::Append(const T& object)
 {
   CheckCapacityToAdd();
   new (mBuffer + (mSize++)) T{ object };
@@ -507,9 +523,9 @@ ArrayList<T>::Append(const T& object)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 void
-ArrayList<T>::Append(T&& object)
+ArrayList<T, R>::Append(T&& object)
 {
   CheckCapacityToAdd();
   new (mBuffer + (mSize++)) T{ std::move(object) };
@@ -517,10 +533,10 @@ ArrayList<T>::Append(T&& object)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 template<typename... ARGS>
 T&
-ArrayList<T>::AppendEmplace(ARGS&&... arguments)
+ArrayList<T, R>::AppendEmplace(ARGS&&... arguments)
 {
   CheckCapacityToAdd();
   new (mBuffer + mSize) T{ std::forward<ARGS>(arguments)... };
@@ -529,14 +545,13 @@ ArrayList<T>::AppendEmplace(ARGS&&... arguments)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 void
-ArrayList<T>::Prepend(const T& object)
+ArrayList<T, R>::Prepend(const T& object)
 {
   CheckCapacityToAdd();
-  for (SizeType i = mSize - 1; i > 0; ++i) {
-    mBuffer[i] = std::move(mBuffer[i - 1]);
-    mBuffer[i - 1].~T();
+  for (SizeType i = (mSize > 0) ? (mSize - 1) : 0; i > 0; --i) {
+    Relocate(mBuffer + i, mBuffer + i - 1);
   }
   new (mBuffer) T{ object };
   ++mSize;
@@ -544,14 +559,13 @@ ArrayList<T>::Prepend(const T& object)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 void
-ArrayList<T>::Prepend(T&& object)
+ArrayList<T, R>::Prepend(T&& object)
 {
   CheckCapacityToAdd();
-  for (SizeType i = mSize - 1; i > 0; ++i) {
-    mBuffer[i] = std::move(mBuffer[i - 1]);
-    mBuffer[i - 1].~T();
+  for (SizeType i = (mSize > 0) ? (mSize - 1) : 0; i > 0; --i) {
+    Relocate(mBuffer + i, mBuffer + i - 1);
   }
   new (mBuffer) T{ std::move(object) };
   ++mSize;
@@ -559,15 +573,14 @@ ArrayList<T>::Prepend(T&& object)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 template<typename... ARGS>
 T&
-ArrayList<T>::PrependEmplace(ARGS&&... arguments)
+ArrayList<T, R>::PrependEmplace(ARGS&&... arguments)
 {
   CheckCapacityToAdd();
-  for (SizeType i = mSize - 1; i > 0; ++i) {
-    mBuffer[i] = std::move(mBuffer[i - 1]);
-    mBuffer[i - 1].~T();
+  for (SizeType i = (mSize > 0) ? (mSize - 1) : 0; i > 0; --i) {
+    Relocate(mBuffer + i, mBuffer + i - 1);
   }
   new (mBuffer) T{ std::forward<ARGS>(arguments)... };
   ++mSize;
@@ -576,9 +589,9 @@ ArrayList<T>::PrependEmplace(ARGS&&... arguments)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 void
-ArrayList<T>::Remove(SizeType index)
+ArrayList<T, R>::Remove(SizeType index)
 {
   // Assert preconditions
   AlfAssert(index >= 0 && index < mSize,
@@ -587,24 +600,22 @@ ArrayList<T>::Remove(SizeType index)
   // Destruct object and move other into spots
   mBuffer[index].~T();
   for (SizeType i = index; i < mSize - 1; ++i) {
-    new (mBuffer + i) T{ std::move(mBuffer[i + 1]) };
-    mBuffer[i + 1].~T();
+    Relocate(mBuffer + i, mBuffer + i + 1);
   }
   mSize--;
 }
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 void
-ArrayList<T>::Remove(const T& object)
+ArrayList<T, R>::RemoveObject(const T& object)
 {
   for (SizeType i = 0; i < mSize; ++i) {
     if (this[i] == object) {
       mBuffer[i].~T();
       for (SizeType j = i; j < mSize - 1; ++j) {
-        new (mBuffer + j) T{ std::move(mBuffer[j + 1]) };
-        mBuffer[j + 1].~T();
+        Relocate(mBuffer + j, mBuffer + j + 1);
       }
       mSize--;
       return;
@@ -614,16 +625,15 @@ ArrayList<T>::Remove(const T& object)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 void
-ArrayList<T>::Remove(T&& object)
+ArrayList<T, R>::RemoveObject(T&& object)
 {
   for (SizeType i = 0; i < mSize; ++i) {
     if (this[i] == object) {
       mBuffer[i].~T();
       for (SizeType j = i; j < mSize - 1; ++j) {
-        new (mBuffer + j) T{ std::move(mBuffer[j + 1]) };
-        mBuffer[j + 1].~T();
+        Relocate(mBuffer + j, mBuffer + j + 1);
       }
       mSize--;
       return;
@@ -633,9 +643,9 @@ ArrayList<T>::Remove(T&& object)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 void
-ArrayList<T>::Resize(SizeType size)
+ArrayList<T, R>::Resize(SizeType size)
 {
   if (size < mCapacity) {
     // Destruct objects if new size is lesser
@@ -652,8 +662,7 @@ ArrayList<T>::Resize(SizeType size)
     T* newBuffer =
       static_cast<T*>(mAllocator.Alloc(size * OBJECT_SIZE, alignof(T)));
     for (SizeType i = 0; i < Min(mSize, size); ++i) {
-      new (newBuffer + i) T{ std::move(mBuffer[i]) };
-      mBuffer[i].~T();
+      Relocate(newBuffer + i, mBuffer + i);
     }
     for (SizeType i = mSize; i < size; ++i) {
       new (newBuffer + i) T{};
@@ -666,17 +675,16 @@ ArrayList<T>::Resize(SizeType size)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 void
-ArrayList<T>::Reserve(SizeType capacity)
+ArrayList<T, R>::Reserve(SizeType capacity)
 {
   // Only do something if new capacity is greater than old
   if (capacity > mCapacity) {
     T* newBuffer =
       static_cast<T*>(mAllocator.Alloc(capacity * OBJECT_SIZE, alignof(T)));
     for (SizeType i = 0; i < mSize; ++i) {
-      new (newBuffer + i) T{ std::move(mBuffer[i]) };
-      mBuffer[i].~T();
+      Relocate(newBuffer + i, mBuffer + i);
     }
     mAllocator.Free(mBuffer);
     mBuffer = newBuffer;
@@ -686,9 +694,9 @@ ArrayList<T>::Reserve(SizeType capacity)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 void
-ArrayList<T>::Shrink(SizeType capacity)
+ArrayList<T, R>::Shrink(SizeType capacity)
 {
   // Only shrink if new capacity is less than old
   if (capacity < mCapacity) {
@@ -709,18 +717,18 @@ ArrayList<T>::Shrink(SizeType capacity)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 void
-ArrayList<T>::ShrinkToFit()
+ArrayList<T, R>::ShrinkToFit()
 {
   Shrink(mSize);
 }
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 bool
-ArrayList<T>::Contains(const T& object)
+ArrayList<T, R>::Contains(const T& object)
 {
   for (SizeType i = 0; i < mSize; ++i) {
     if (At(i) == object) {
@@ -732,9 +740,9 @@ ArrayList<T>::Contains(const T& object)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 T&
-ArrayList<T>::At(SizeType index)
+ArrayList<T, R>::At(SizeType index)
 {
   // Assert precondition
   AlfAssert(index >= 0 && index < mSize,
@@ -744,9 +752,9 @@ ArrayList<T>::At(SizeType index)
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 const T&
-ArrayList<T>::At(SizeType index) const
+ArrayList<T, R>::At(SizeType index) const
 {
   // Assert precondition
   AlfAssert(index >= 0 && index < mSize,
@@ -756,29 +764,42 @@ ArrayList<T>::At(SizeType index) const
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
-T& ArrayList<T>::operator[](SizeType index)
+template<typename T, bool R>
+T& ArrayList<T, R>::operator[](SizeType index)
 {
   return At(index);
 }
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
-const T& ArrayList<T>::operator[](SizeType index) const
+template<typename T, bool R>
+const T& ArrayList<T, R>::operator[](SizeType index) const
 {
   return At(index);
 }
 
 // -------------------------------------------------------------------------- //
 
-template<typename T>
+template<typename T, bool R>
 void
-ArrayList<T>::CheckCapacityToAdd()
+ArrayList<T, R>::CheckCapacityToAdd()
 {
   if (mSize >= mCapacity) {
     Reserve(mCapacity ? mCapacity * RESIZE_FACTOR : DEFAULT_CAPACITY);
   }
 }
+
+}
+
+// ========================================================================== //
+// Specialization for relocatable T
+// ========================================================================== //
+
+namespace alflib {
+
+/*template<typename T>
+class ArrayList<T, true>
+{
+};*/
 
 }

--- a/include/alflib/core/traits.hpp
+++ b/include/alflib/core/traits.hpp
@@ -1,0 +1,82 @@
+// MIT License
+//
+// Copyright (c) 2019 Filip Björklund
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+// ========================================================================== //
+// Headers
+// ========================================================================== //
+
+// Project headers
+#include "alflib/core/common.hpp"
+
+// ========================================================================== //
+// IsTriviallyRelocatable
+// ========================================================================== //
+
+#define ALFLIB_DEFINE_TRIVIALLY_RELOCATABLE(type)                              \
+  template<>                                                                   \
+  struct IsTriviallyRelocatable<type>                                          \
+  {                                                                            \
+    static constexpr bool Value = true;                                        \
+  };
+
+namespace alflib {
+
+/** Trait that determines whether or not a type is trivially relocatable.
+ * Meaning that we don't need to use a 'Move-Destruct' pair when moving the data
+ * of the object, but can rather just use a 'memcpy'.
+ * \brief Trait for trivially relocatable types.
+ * \tparam T Type that may be trivially relocatable.
+ */
+template<typename T>
+struct IsTriviallyRelocatable
+{
+  static constexpr bool Value = false;
+};
+
+// -------------------------------------------------------------------------- //
+
+/** \copydoc alflib::IsTriviallyRelocatable<T> **/
+template<typename T>
+struct IsTriviallyRelocatable<T*>
+{
+  static constexpr bool Value = true;
+};
+
+// -------------------------------------------------------------------------- //
+
+ALFLIB_DEFINE_TRIVIALLY_RELOCATABLE(char);
+ALFLIB_DEFINE_TRIVIALLY_RELOCATABLE(unsigned char);
+ALFLIB_DEFINE_TRIVIALLY_RELOCATABLE(short);
+ALFLIB_DEFINE_TRIVIALLY_RELOCATABLE(unsigned short);
+ALFLIB_DEFINE_TRIVIALLY_RELOCATABLE(int);
+ALFLIB_DEFINE_TRIVIALLY_RELOCATABLE(unsigned int);
+ALFLIB_DEFINE_TRIVIALLY_RELOCATABLE(long);
+ALFLIB_DEFINE_TRIVIALLY_RELOCATABLE(unsigned long);
+ALFLIB_DEFINE_TRIVIALLY_RELOCATABLE(long long);
+ALFLIB_DEFINE_TRIVIALLY_RELOCATABLE(unsigned long long);
+ALFLIB_DEFINE_TRIVIALLY_RELOCATABLE(float);
+ALFLIB_DEFINE_TRIVIALLY_RELOCATABLE(double);
+ALFLIB_DEFINE_TRIVIALLY_RELOCATABLE(long double);
+
+}

--- a/include/alflib/memory/memory.hpp
+++ b/include/alflib/memory/memory.hpp
@@ -28,6 +28,7 @@
 
 // Project headers
 #include "alflib/core/common.hpp"
+#include "alflib/core/traits.hpp"
 
 // ========================================================================== //
 // Functions
@@ -78,6 +79,31 @@ SwapEndian(u64 value)
          ((value & 0x0000000000ff0000ull) << 24u) |
          ((value & 0x000000000000ff00ull) << 40u) |
          ((value & 0x00000000000000ffull) << 56u);
+}
+
+// -------------------------------------------------------------------------- //
+
+/** Relocate memory from the source memory location to the destination location.
+ * If the type is trivially relocatable then this will copy the memory using
+ * 'memcpy' instead of invoking the move constructor and then destruct the
+ * source value.
+ * \brief Relocate memory.
+ * \tparam T Type of object to relocate memory of.
+ * \param destination Destination address.
+ * \param source Source address.
+ * \return Destination address.
+ */
+template<typename T>
+T*
+Relocate(T* destination, T* source)
+{
+  if constexpr (!IsTriviallyRelocatable<T>::Value) {
+    ::new (destination) T{ std::move(*source) };
+    source->~T();
+  } else {
+    memcpy(destination, source, sizeof(T));
+  }
+  return destination;
 }
 
 }


### PR DESCRIPTION
* Added a trait that is used to determine if an object is trivially relocatable, meaning that memory can be memcpy:ed.
* Updated the ArrayList class to make use of relocation
* Updated tests to correctly test the ArrayList both in cases of trivially relocatable object and non-trivially relocatable objects