### PR TITLE
AlfAssert now correctly forces the contidion to evaluate to boolean. …

### DIFF
--- a/include/alflib/core/assert.hpp
+++ b/include/alflib/core/assert.hpp
@@ -48,7 +48,7 @@
 #pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 /** Macro for asserting that a condition is true **/
 #define AlfAssert(condition, messageFormat, ...)                               \
-  alflib::Assert(condition, __FILE__, __LINE__, messageFormat, ##__VA_ARGS__)
+  alflib::Assert(!!(condition), __FILE__, __LINE__, messageFormat, ##__VA_ARGS__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/source/alflib/core/assert.cpp
+++ b/source/alflib/core/assert.cpp
@@ -30,6 +30,7 @@
 #include "alflib/core/dialog.hpp"
 #include "alflib/core/console.hpp"
 #include "alflib/debug/debugger.hpp"
+#include <iostream>
 
 // ========================================================================== //
 // Functions
@@ -51,6 +52,7 @@ Assert(bool condition, const char8* file, u32 line, const String& message)
 
   // Print to stdout and show dialog
   Console::WriteLine(output);
+  std::cout << std::endl; // flushes the output
   ShowErrorDialog("Assertion", output);
 
   // Break debugger then abort execution


### PR DESCRIPTION
…AlfAssert now correctly flushes stdout to make sure the error message is printed out.